### PR TITLE
Using the latest reach v1.4.1-SNAPSHOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ RUN apt-get update && apt-get install -y git
 RUN mkdir -p /nlp
 
 # Fetch the (fork) branch and checkout commit 
-RUN cd /nlp && git clone -b master https://github.com/IgorRodchenkov/reach.git
+RUN cd /nlp && git clone -b master https://github.com/clulab/reach.git
 WORKDIR /nlp/reach
-# RUN git checkout v1.4.1
+# RUN git checkout v1.4.0
 
 # Make changes to the configuration files.
 # Set default timeouts 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y wget tree htop zip unzip && \
     echo "exit" | sbt
 
 # --- INSTALL REACH ---
-# https://github.com/clulab/reach/tree/72064c6abb442bfa84cc89e0f00fb50c3a9ffa6c
+# https://github.com/clulab/reach/tree/5b9166fdf74e7c4932240b16fd8a43aef6b8bdc6
 
 RUN apt-get update && apt-get install -y git
 
@@ -53,7 +53,7 @@ RUN mkdir -p /nlp
 # Fetch the (fork) branch and checkout commit 
 RUN cd /nlp && git clone -b master https://github.com/clulab/reach.git
 WORKDIR /nlp/reach
-# RUN git checkout v1.4.0
+RUN git checkout 5b9166fdf74e7c4932240b16fd8a43aef6b8bdc6
 
 # Make changes to the configuration files.
 # Set default timeouts 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,10 @@ RUN apt-get update && apt-get install -y git
 # Fetch the branch and checkout commit 
 RUN mkdir -p /nlp
 
-# Fetch the branch and checkout commit 
-RUN cd /nlp && git clone -b master https://github.com/clulab/reach.git
+# Fetch the (fork) branch and checkout commit 
+RUN cd /nlp && git clone -b master https://github.com/IgorRodchenkov/reach.git
 WORKDIR /nlp/reach
-RUN git checkout 72064c6abb442bfa84cc89e0f00fb50c3a9ffa6c 
+# RUN git checkout v1.4.1
 
 # Make changes to the configuration files.
 # Set default timeouts 
@@ -69,7 +69,7 @@ COPY sbt.sh /
 
 # Run as unprivileged pcuser
 RUN adduser --system --home /home/pcuser --shell /bin/bash --group pcuser
-RUN chown pcuser:pcuser /nlp/reach/target/scala-2.11/reach-1.3.5-SNAPSHOT-FAT.jar
+RUN chown pcuser:pcuser /nlp/reach/target/scala-2.11/reach-1.4.1-SNAPSHOT-FAT.jar
 USER pcuser
 RUN mkdir -p /home/pcuser/Documents/reach
 

--- a/sbt.sh
+++ b/sbt.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-SBT_OPTS="-Xmx6G -Xms4G"
-exec java $SBT_OPTS -jar reach-1.3.5-SNAPSHOT-FAT.jar
+SBT_OPTS="-Xmx8G -Xms4G"
+exec java $SBT_OPTS -jar reach-1.4.1-SNAPSHOT-FAT.jar


### PR DESCRIPTION
This is the latest, suitable for Factoid, Reach version that uses BioNLP processor.
Let's run this one instead of 1.3 at reach.baderlab.org.